### PR TITLE
[FEAT] Load info on init

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
 <app-searchbar></app-searchbar>
+<app-container></app-container>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,11 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { AppComponent } from './app.component';
 
 import { SearchbarComponent } from './components/searchbar/searchbar.component';
+import { ContainerComponent } from './components/container/container.component';
 
 describe('AppComponent', () => {
   beforeEach(() => TestBed.configureTestingModule({
     imports: [HttpClientTestingModule, FormsModule],
-    declarations: [AppComponent, SearchbarComponent]
+    declarations: [AppComponent, SearchbarComponent, ContainerComponent]
   }).compileComponents());
 
   it('should create the app', () => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,11 +8,13 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from  '@angular/common/http';
 
 import { SearchbarComponent } from './components/searchbar/searchbar.component';
+import { ContainerComponent } from './components/container/container.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     SearchbarComponent,
+    ContainerComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/container/container.component.html
+++ b/src/app/components/container/container.component.html
@@ -1,0 +1,3 @@
+<div>
+    {{ pokemons | async | json}}
+</div>

--- a/src/app/components/container/container.component.spec.ts
+++ b/src/app/components/container/container.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PokemonService } from '../../services/pokemon.service';
+import { ContainerComponent } from './container.component';
+
+describe('ContainerComponent', () => {
+  let component: ContainerComponent;
+  let fixture: ComponentFixture<ContainerComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PokemonService],
+      declarations: [ContainerComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/container/container.component.ts
+++ b/src/app/components/container/container.component.ts
@@ -1,0 +1,39 @@
+import { Component, Input, OnInit, Output } from '@angular/core';
+import { PokemonService } from '../../services/pokemon.service';
+import { Observable } from 'rxjs';
+import Pokemon from '../../models/Pokemon';
+
+@Component({
+  selector: 'app-container',
+  templateUrl: './container.component.html',
+  styleUrls: ['./container.component.css']
+})
+
+/**
+ * @class ContainerComponent
+ * @description This component is responsible for the initial loding of the pokemon list and for the pagination
+ * @property { boolean } loading - The loading state of the component
+ * @property { boolean } loadingChange - The loading state of the component
+ * @property { Observable<Pokemon[]> } pokemons - The list of pokemons
+ * 
+ * @example <app-container></app-container>
+ * 
+ * @method ngOnInit - This method is responsible for initializing the component
+ * 
+ */
+export class ContainerComponent implements OnInit {
+  @Input() loading: boolean;
+  @Output() loadingChange: boolean;
+  pokemons : Observable<Pokemon[]> = new Observable<Pokemon[]>();
+
+  constructor(private pokemonService : PokemonService) {
+    this.loading = true;
+    this.loadingChange = false;
+  }
+
+  ngOnInit(): void {
+    this.pokemons = this.pokemonService.getPokemons();
+    this.loading = false;
+    this.loadingChange = true;
+  }
+}

--- a/src/app/components/searchbar/searchbar.component.html
+++ b/src/app/components/searchbar/searchbar.component.html
@@ -13,6 +13,6 @@
         </button>
     </form>
 </div>
-<div>
-    {{ pokemonInfo | json }}
+<div *ngIf="searchForm.submitted">
+    {{ pokemonInfo | async | json }}
 </div>

--- a/src/app/components/searchbar/searchbar.component.ts
+++ b/src/app/components/searchbar/searchbar.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { PokemonService } from '../../services/pokemon.service';
-
+import Pokemon from '../../models/Pokemon';
+import { Observable } from 'rxjs';
 @Component({
   selector: 'app-searchbar',
   templateUrl: './searchbar.component.html',
@@ -18,32 +19,24 @@ import { PokemonService } from '../../services/pokemon.service';
  * 
  * @returns { void } 
  */
-export class SearchbarComponent implements OnInit {
+export class SearchbarComponent {
   pokemonName!: string;
-  pokemonInfo!: any;
-
+  pokemonInfo : Observable<Pokemon> = new Observable<Pokemon>();
+  
   // Inject the pokemon service into the constructor
   constructor(private pokemonService: PokemonService) { }
 
-  ngOnInit(): void {
-  }
-
+  /**
+   * @method searchPokemon
+   * @description This method is responsible for searching for the pokemon.
+   * If the pokemonName is not empty, it will return the pokemon with the given name.
+   * 
+   * @param { string } pokemonName - The name of the pokemon to search for
+   * 
+   * @returns { void }
+   */
   searchPokemon(pokemonName: string) {
-
-    // If there is no pokemon name, get all pokemons
-    if (!pokemonName) {
-      this.pokemonInfo = this.pokemonService.getPokemons().subscribe(
-        (data: any) => {
-          this.pokemonInfo = data;
-        }
-      )
-    }
-
-    // Get the pokemon by name
-    this.pokemonInfo = this.pokemonService.getPokemon(pokemonName).subscribe(
-      (data: any) => {
-        this.pokemonInfo = data;
-      }
-    )
+    if (pokemonName === '') return;
+    this.pokemonInfo = this.pokemonService.getPokemon(pokemonName);
   }
 }

--- a/src/app/models/Pokemon.ts
+++ b/src/app/models/Pokemon.ts
@@ -1,0 +1,21 @@
+interface Pokemon {
+    id: number;
+    name: string;
+    sprite: string|null;
+    animateSprite: string|null;
+    types: string[];
+    height: number;
+    weight: number;
+    abilities: string[];
+    stats: {
+        name: string;
+        value: number;
+    }[];
+    evolutions: {
+        id: number;
+        name: string;
+        sprite: string;
+    }[];
+}
+
+export default Pokemon;

--- a/src/app/services/pokemon.service.ts
+++ b/src/app/services/pokemon.service.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from  '@angular/common/http';
-import {Observable} from 'rxjs';
+import {Observable, combineLatest, map, switchMap } from 'rxjs';
+
+import Pokemon from '../models/Pokemon';
 
 const APIURL = 'https://pokeapi.co/api/v2/pokemon/';
+const DEFAULTLIMIT = 20;
 
 @Injectable({
   providedIn: 'root'
@@ -15,10 +18,30 @@ export class PokemonService {
    * Get pokemon by name
    * 
    * @param pokemonName pokemon name to search for
-   * @returns { Observable<any> }
+   * @returns { Observable<Pokemon> }
    */
-  getPokemon(pokemonName: string) : Observable<any> {
-    return this.http.get(`${APIURL}${pokemonName}`)
+  getPokemon(pokemonName: string) : Observable<Pokemon> {
+    const response = this.http.get<any>(`${APIURL}${pokemonName}`);
+    return response.pipe( map((data: any) => {
+      return {
+        id: data.id,
+        name: data.name,
+        sprite: data.sprites.front_default,
+        animateSprite: data.sprites.versions['generation-v']['black-white'].animated.front_default,
+        types: data.types.map((type: any) => type.type.name),
+        height: data.height,
+        weight: data.weight,
+        abilities: data.abilities.map((ability: any) => ability.ability.name),
+        stats: data.stats.map((stat: any) => {
+          return {
+            name: stat.stat.name,
+            value: stat.base_stat
+          }
+        }),
+        evolutions: []
+      }
+    }
+    )) as Observable<Pokemon>;
   }
 
   /**
@@ -27,7 +50,22 @@ export class PokemonService {
    * @returns { Observable<any> }
    * 
    */
-  getPokemons() : Observable<any> {
-    return this.http.get(`${APIURL}`)
+  getPokemons() : Observable<Pokemon[]> {
+    //@TODO: Provide offset for pagination
+    const response = this.http.get<any>(`${APIURL}?limit=${DEFAULTLIMIT}`);
+    return response.pipe(
+      map((data: any) => {
+        return data.results.map((pokemon: any) => {
+          return pokemon.name;
+        });
+      }),
+      switchMap((pokemons: string[]) => {
+        const completePokemonData : Observable<Pokemon>[] = []; 
+        pokemons.forEach((pokemon: string) => {
+          completePokemonData.push(this.getPokemon(pokemon));
+        });
+        return combineLatest(completePokemonData);
+      }),
+    ) as Observable<Pokemon[]>;
   }
 }


### PR DESCRIPTION
- Add interface for pokemon details
- Change pokemon service logic to get all the needed information from the API.
- Implement a container component to handle first load.
- Add test for the new feature

Other pokemon information will be loaded on scroll in the next PR/feature branch. Input and output decorators currently not used but probably needed for the next feature.